### PR TITLE
modify EvaluateCostFunctionGradient()

### DIFF
--- a/ifopt_core/include/ifopt/problem.h
+++ b/ifopt_core/include/ifopt/problem.h
@@ -176,7 +176,7 @@ public:
    */
   VectorXd EvaluateCostFunctionGradient(const double* x,
                                         bool use_finite_difference_approximation = false,
-                                        double epsilon = std::numeric_limits<double>::epsilon());
+                                        double epsilon = 1e-8); // epsilon = std::numeric_limits<double>::epsilon()
 
   /**
    * @brief The number of individual constraints.


### PR DESCRIPTION
According to [this](https://github.com/ethz-adrl/ifopt/issues/70), the EvaluateCostFunctionGradient numerical difference produces incorrect gradients when using squared cost, because it uses a step size of 1e-16 for automatic numerical difference "finite-difference-values".

Thus, I change the default step size from 1e-16 to 1e-8, according to [this](https://github.com/ethz-adrl/ifopt/issues/70).